### PR TITLE
Symfony 4 support + support overwrite of Entity/Domain

### DIFF
--- a/Entity/Domain.php
+++ b/Entity/Domain.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Domain
  *
- * @ORM\Table()
+ * @ORM\Table(name="Domain")
  * @ORM\Entity
  */
 class Domain

--- a/Entity/Domain.php
+++ b/Entity/Domain.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Domain
  *
- * @ORM\Table(name="Domain")
+ * @ORM\Table
  * @ORM\Entity
  */
 class Domain

--- a/EventListener/DomainListener.php
+++ b/EventListener/DomainListener.php
@@ -18,6 +18,8 @@ class DomainListener
     {
         $request = $event->getRequest();
 
-        $this->em->getFilters()->getFilter('domain')->setParameter('domain', $request->getHost());
+        $this->em->getFilters()->getFilter('domain')
+            ->setParameter('domain', $request->getHost())
+            ->setEntityManager($this->em);
     }
 }

--- a/ORM/Filter/DomainFilter.php
+++ b/ORM/Filter/DomainFilter.php
@@ -2,19 +2,28 @@
 
 namespace AppVentus\MultiDomainBundle\ORM\Filter;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Filter\SQLFilter;
 use Doctrine\ORM\Mapping\ClassMetaData;
+use AppVentus\MultiDomainBundle\Entity\Domain;
 
 class DomainFilter extends SQLFilter
 {
+    protected $manager;
+
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
-	if (!$targetEntity->hasAssociation('domain')) {
-	    return true;
-	}
-        $select = "SELECT d.id as id FROM Domain d WHERE d.id = ".$targetTableAlias.'.domain_id';
-
-
+        if (!$targetEntity->hasAssociation('domain')) {
+            return true;
+        }
+        $tableName = $this->manager->getClassMetadata(Domain::class)->getTableName() ;
+    
+        $select = "SELECT d.id as id FROM `{$tableName}` d WHERE d.id = ".$targetTableAlias.'.domain_id';
         return $select.' AND d.name = '. $this->getParameter('domain');
+    }
+
+    public function setEntityManager ($em) {
+        $this->manager = $em;
+        return $this;
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ add
     }
 }
 ```
-    
+
 in your composer.json
+or `composer require appventus/multi-domain-bundle`
+
+register the bundle adding it to your bundles.php file
+```php
+return [
+	[...]
+	AppVentus\MultiDomainBundle\AvMultiDomainBundle::class => ['all' => true],
+];
+```
 
 and add the DomainTrait to all your domain managed entities:
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,8 @@
 services:
     kernel.listener.domain_listener:
         class: AppVentus\MultiDomainBundle\EventListener\DomainListener
-        arguments: [@doctrine.orm.entity_manager]
+        arguments: 
+            - "@doctrine.orm.entity_manager"
         tags:
             - { name: kernel.event_listener, event: kernel.request, method: onDomainParse }
 


### PR DESCRIPTION
I was looking around for something like this for Symfony 4 and with these few changes I have extended the support.

I also have added a call to the entity manager in the domain query filter that reads the table name from the entity, so that i can overwrite the domain entity and change the table name as i wish.

I have not tested it with Symfony 3